### PR TITLE
show_chain shouldn't stop at modules that aren't in sys.modules

### DIFF
--- a/docs/generator-sample.txt
+++ b/docs/generator-sample.txt
@@ -38,12 +38,11 @@ and we can see what holds it in memory
    :alt: [graph of objects from which the canary is reachable]
    :scale: 50%
 
-Or we can examine just one of the reference chains leading straight a module.
+Or we can examine just one of the reference chains leading straight to a module.
 
-    >>> import inspect
     >>> objgraph.show_chain(
     ...     objgraph.find_backref_chain(objgraph.by_type('Canary')[0],
-    ...                                 inspect.ismodule),
+    ...                                 objgraph.is_proper_module),
     ...     filename='canary-chain.png')
     Graph written to ....dot (11 nodes)
     Image generated as canary-chain.png

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -97,15 +97,16 @@ It's easy to see :class:`MyBigFatObject` instances that appeared and were
 not freed.  I can pick one of them at random and trace the reference chain
 back to one of the garbage collector's roots.
 
-For simplicity's sake let's assume all of the roots are modules; if you've
-any examples where that isn't true, I'd love to hear about them (although
-see :ref:`leaking-objects`).
+For simplicity's sake let's assume all of the roots are modules.  ``objgraph``
+provides a function, :func:`~objgraph.is_proper_module`, to check this. If
+you've any examples where that isn't true, I'd love to hear about them
+(although see :ref:`leaking-objects`).
 
-    >>> import inspect, random
+    >>> import random
     >>> objgraph.show_chain(
     ...     objgraph.find_backref_chain(
     ...         random.choice(objgraph.by_type('MyBigFatObject')),
-    ...         inspect.ismodule),
+    ...         objgraph.is_proper_module),
     ...     filename='chain.png')
     Graph written to ...dot (13 nodes)
     Image generated as chain.png

--- a/docs/objgraph.txt
+++ b/docs/objgraph.txt
@@ -29,6 +29,8 @@ Locating and Filtering Objects
 
 .. autofunction:: at
 
+.. autofunction:: is_proper_module(obj)
+
 
 Traversing and Displaying Object Graphs
 ---------------------------------------


### PR DESCRIPTION
A module shouldn't be considered a gc root unless it's actually in sys.modules.

Should the examples be updated to use the new `is_root` function instead of `inspect.ismodule`?
