### PR TITLE
Handle file objects without encoding attribute set

### DIFF
--- a/objgraph.py
+++ b/objgraph.py
@@ -588,7 +588,7 @@ def show_graph(objs, edge_func, swap_source_target,
         fd, dot_filename = tempfile.mkstemp(prefix='objgraph-',
                                             suffix='.dot', text=True)
         f = os.fdopen(fd, "w")
-        if f.encoding:
+        if getattr(f, 'encoding', None):
             # Python 3 will wrap the file in the user's preferred encoding
             # Re-wrap it for utf-8
             import io


### PR DESCRIPTION
`file.encoding` attribute doesn't need to be present (https://docs.python.org/2/library/stdtypes.html#file.encoding), this patch makes objgraph work with Eventlet and monkey patching.
