### PR TITLE
Make show_graph accept a file-like object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes
 1.8.2 (unreleased)
 ------------------
 
+- Allow user to provide file object rather than specify a filename.
 
 1.8.1 (2014-05-15)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changes
 
 .. currentmodule:: objgraph
 
-1.9 (unreleased)
+1.9.0 (unreleased)
 ------------------
 
 - :func:`show_ref` and :func:`show_backref` now accept a file-like object as an

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,11 +3,12 @@ Changes
 
 .. currentmodule:: objgraph
 
-1.8.2 (unreleased)
+1.9 (unreleased)
 ------------------
 
 - :func:`show_ref` and :func:`show_backref` now accept a file-like object as an
   alternative to a filename.
+
 
 1.8.1 (2014-05-15)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changes
 1.8.2 (unreleased)
 ------------------
 
-- Allow user to provide file object rather than specify a filename.
+- :func:`show_ref` and :func:`show_backref` now accept a file-like object as an
+  alternative to a filename.
 
 1.8.1 (2014-05-15)
 ------------------

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -24,6 +24,9 @@ You should see a graph like this:
 .. figure:: sample-graph.png
    :alt: [graph of objects reachable from y]
 
+If you prefer to handle your own file output, you can provide a file object to
+the ``output`` parameter of ``show_refs`` and ``show_backrefs`` instead of a
+filename.
 
 Backreferences
 --------------

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -26,7 +26,7 @@ You should see a graph like this:
 
 If you prefer to handle your own file output, you can provide a file object to
 the ``output`` parameter of ``show_refs`` and ``show_backrefs`` instead of a
-filename.
+filename. The contents of this file will contain the graph source in DOT format.
 
 Backreferences
 --------------

--- a/objgraph.py
+++ b/objgraph.py
@@ -29,7 +29,7 @@ Released under the MIT licence.
 __author__ = "Marius Gedminas (marius@gedmin.as)"
 __copyright__ = "Copyright (c) 2008-2014 Marius Gedminas"
 __license__ = "MIT"
-__version__ = "1.8.2.dev0"
+__version__ = "1.9"
 __date__ = "2014-05-15"
 
 
@@ -408,7 +408,7 @@ def show_backrefs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     .. versionchanged:: 1.8
        New parameter: ``shortnames``.
 
-    .. versionchanged:: 1.8.2
+    .. versionchanged:: 1.9
        New parameter: ``output``.
 
     """
@@ -476,7 +476,7 @@ def show_refs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     .. versionchanged:: 1.8
        New parameter: ``shortnames``.
 
-    .. versionchanged:: 1.8.2
+    .. versionchanged:: 1.9
        New parameter: ``output``.
     """
     show_graph(objs, max_depth=max_depth, extra_ignore=extra_ignore,
@@ -513,7 +513,7 @@ def show_chain(*chains, **kw):
     .. versionchanged:: 1.7
        New parameter: ``backrefs``.
 
-    .. versionchanged:: 1.8.2
+    .. versionchanged:: 1.9
        New parameter: ``output``.
 
     """
@@ -596,7 +596,7 @@ def show_graph(objs, edge_func, swap_source_target,
     if not isinstance(objs, (list, tuple)):
         objs = [objs]
     if filename and output:
-        raise ValueError('Cannot specify output and filename.')
+        raise ValueError('Cannot specify both output and filename.')
     elif output:
         f = output
     elif filename and filename.endswith('.dot'):

--- a/objgraph.py
+++ b/objgraph.py
@@ -350,7 +350,7 @@ def find_backref_chain(obj, predicate, max_depth=20, extra_ignore=()):
 
 def show_backrefs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
                   highlight=None, filename=None, extra_info=None,
-                  refcounts=False, shortnames=True):
+                  refcounts=False, shortnames=True, output=None):
     """Generate an object reference graph ending at ``objs``.
 
     The graph will show you what objects refer to ``objs``, directly and
@@ -363,10 +363,13 @@ def show_backrefs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     file, whose extension indicates the desired output format; note
     that output to a specific format is entirely handled by GraphViz:
     if the desired format is not supported, you just get the .dot
-    file.  If ``filename`` is not specified, ``show_backrefs`` will
-    try to produce a .dot file and spawn a viewer (xdot).  If xdot is
+    file.  If ``filename`` and ``output`` is not specified, ``show_backrefs``
+    will try to produce a .dot file and spawn a viewer (xdot).  If xdot is
     not available, ``show_backrefs`` will convert the .dot file to a
     .png and print its name.
+
+    ``output`` if specified, the GraphViz output will be written to this
+    file object. ``output`` and ``filename`` should not both be specified.
 
     Use ``max_depth`` and ``too_many`` to limit the depth and breadth of the
     graph.
@@ -405,17 +408,20 @@ def show_backrefs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     .. versionchanged:: 1.8
        New parameter: ``shortnames``.
 
+    .. versionchanged:: 1.8.2
+       New parameter: ``output``.
+
     """
     show_graph(objs, max_depth=max_depth, extra_ignore=extra_ignore,
                filter=filter, too_many=too_many, highlight=highlight,
                edge_func=gc.get_referrers, swap_source_target=False,
-               filename=filename, extra_info=extra_info, refcounts=refcounts,
+               filename=filename, output=output, extra_info=extra_info, refcounts=refcounts,
                shortnames=shortnames)
 
 
 def show_refs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
               highlight=None, filename=None, extra_info=None,
-              refcounts=False, shortnames=True):
+              refcounts=False, shortnames=True, output=None):
     """Generate an object reference graph starting at ``objs``.
 
     The graph will show you what objects are reachable from ``objs``, directly
@@ -428,10 +434,13 @@ def show_refs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     file, whose extension indicates the desired output format; note
     that output to a specific format is entirely handled by GraphViz:
     if the desired format is not supported, you just get the .dot
-    file.  If ``filename`` is not specified, ``show_refs`` will
+    file.  If ``filename`` and ``output`` is not specified, ``show_refs`` will
     try to produce a .dot file and spawn a viewer (xdot).  If xdot is
     not available, ``show_refs`` will convert the .dot file to a
     .png and print its name.
+
+    ``output`` if specified, the GraphViz output will be written to this
+    file object. ``output`` and ``filename`` should not both be specified.
 
     Use ``max_depth`` and ``too_many`` to limit the depth and breadth of the
     graph.
@@ -467,12 +476,14 @@ def show_refs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     .. versionchanged:: 1.8
        New parameter: ``shortnames``.
 
+    .. versionchanged:: 1.8.2
+       New parameter: ``output``.
     """
     show_graph(objs, max_depth=max_depth, extra_ignore=extra_ignore,
                filter=filter, too_many=too_many, highlight=highlight,
                edge_func=gc.get_referents, swap_source_target=True,
                filename=filename, extra_info=extra_info, refcounts=refcounts,
-               shortnames=shortnames)
+               shortnames=shortnames, output=output)
 
 
 def show_chain(*chains, **kw):
@@ -494,13 +505,16 @@ def show_chain(*chains, **kw):
     symmetrical.
 
     You can specify ``highlight``, ``extra_info``, ``refcounts``,
-    ``shortnames`` or ``filename`` arguments like for :func:`show_backrefs` or
-    :func:`show_refs`.
+    ``shortnames``,``filename`` or ``output`` arguments like for
+    :func:`show_backrefs` or :func:`show_refs`.
 
     .. versionadded:: 1.5
 
     .. versionchanged:: 1.7
        New parameter: ``backrefs``.
+
+    .. versionchanged:: 1.8.2
+       New parameter: ``output``.
 
     """
     backrefs = kw.pop('backrefs', True)
@@ -578,10 +592,14 @@ def find_chain(obj, predicate, edge_func, max_depth=20, extra_ignore=()):
 def show_graph(objs, edge_func, swap_source_target,
                max_depth=3, extra_ignore=(), filter=None, too_many=10,
                highlight=None, filename=None, extra_info=None,
-               refcounts=False, shortnames=True):
+               refcounts=False, shortnames=True, output=None):
     if not isinstance(objs, (list, tuple)):
         objs = [objs]
-    if filename and filename.endswith('.dot'):
+    if filename and output:
+        raise ValueError('Cannot specify output and filename.')
+    elif output:
+        f = output
+    elif filename and filename.endswith('.dot'):
         f = codecs.open(filename, 'w', encoding='utf-8')
         dot_filename = filename
     else:
@@ -677,6 +695,10 @@ def show_graph(objs, edge_func, swap_source_target,
             f.write('  too_many_%s[label="%s",shape=box,height=0.25,color=red,fillcolor="%g,%g,%g",fontsize=6];\n' % (obj_node_id(target), label, h, s, v))
             f.write('  too_many_%s[fontcolor=white];\n' % (obj_node_id(target)))
     f.write("}\n")
+    if output:
+        return
+    # The file should only be closed if this function was in charge of opening
+    # the file.
     f.close()
     print("Graph written to %s (%d nodes)" % (dot_filename, nodes))
     if filename and filename.endswith('.dot'):
@@ -685,7 +707,7 @@ def show_graph(objs, edge_func, swap_source_target,
     if not filename and program_in_path('xdot'):
         print("Spawning graph viewer (xdot)")
         subprocess.Popen(['xdot', dot_filename], close_fds=True)
-    elif program_in_path('dot'):
+    elif filename and program_in_path('dot'):
         if not filename:
             print("Graph viewer (xdot) not found, generating a png instead")
             filename = dot_filename[:-4] + '.png'

--- a/objgraph.py
+++ b/objgraph.py
@@ -707,7 +707,7 @@ def show_graph(objs, edge_func, swap_source_target,
     if not filename and program_in_path('xdot'):
         print("Spawning graph viewer (xdot)")
         subprocess.Popen(['xdot', dot_filename], close_fds=True)
-    elif filename and program_in_path('dot'):
+    elif program_in_path('dot'):
         if not filename:
             print("Graph viewer (xdot) not found, generating a png instead")
             filename = dot_filename[:-4] + '.png'

--- a/objgraph.py
+++ b/objgraph.py
@@ -29,7 +29,7 @@ Released under the MIT licence.
 __author__ = "Marius Gedminas (marius@gedmin.as)"
 __copyright__ = "Copyright (c) 2008-2014 Marius Gedminas"
 __license__ = "MIT"
-__version__ = "1.9"
+__version__ = "1.9.0dev0"
 __date__ = "2014-05-15"
 
 

--- a/tests.py
+++ b/tests.py
@@ -33,11 +33,11 @@ class Python25CompatibleTestCaseMixin:
 
 
 def empty_edge_function(obj):
-  return []
+    return []
 
 
 class TestObject:
-  pass
+    pass
 
 
 class ShowGraphTest(unittest.TestCase, Python25CompatibleTestCaseMixin):
@@ -54,9 +54,9 @@ class ShowGraphTest(unittest.TestCase, Python25CompatibleTestCaseMixin):
 
     def test_filename_and_output(self):
         output = StringIO()
-        self.assertRaises(TypeError,
-            show_graph([], empty_edge_function, False, filename='filename',
-                       output=output)
+        self.assertRaises(ValueError,
+            show_graph, [], empty_edge_function, False, filename='filename',
+            output=output)
 
 # Doc tests
 
@@ -278,7 +278,7 @@ def doctest_edge_label_long_type_names():
     """
 
 
-def suite():
+def test_suite():
     doctests = find_doctests()
     return unittest.TestSuite([
         unittest.defaultTestLoader.loadTestsFromName(__name__),
@@ -291,4 +291,4 @@ def suite():
 
 
 if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+    unittest.main(defaultTest='test_suite')

--- a/tests.py
+++ b/tests.py
@@ -18,6 +18,20 @@ except ImportError:
   from io import StringIO
 
 
+class Python25CompatibleTestCaseMixin:
+
+    def assertRegexpMatches(self, text, expected_regexp, msg=None):
+        if isinstance(expected_regexp, basestring):
+            expected_regexp = re.compile(expected_regexp)
+        if not expected_regexp.search(text):
+            msg = msg or "Regexp didn't match"
+            msg = '%s: %r not found in %r' % (msg, expected_regexp.pattern, text)
+            raise self.failureException(msg)
+
+    def assertIsNotNone(self, value):
+        self.assertTrue(value is not None)
+
+
 # Unit tests
 
 
@@ -29,7 +43,7 @@ class TestObject:
   pass
 
 
-class ShowGraphTest(unittest.TestCase):
+class ShowGraphTest(unittest.TestCase, Python25CompatibleTestCaseMixin):
   """Tests for the show_graph function."""
 
   def test_basic_file_output(self):

--- a/tests.py
+++ b/tests.py
@@ -9,6 +9,41 @@ import shutil
 import tempfile
 import unittest
 
+from objgraph import obj_node_id
+from objgraph import show_graph
+
+try:
+  from cStringIO import StringIO
+except ImportError:
+  from StringIO import StringIO
+
+
+# Unit tests
+
+
+def empty_edge_function(obj):
+  return []
+
+
+class TestObject:
+  pass
+
+
+class ShowGraphTest(unittest.TestCase):
+  """Tests for the show_graph function."""
+
+  def test_basic_file_output(self):
+    obj = TestObject()
+    output = StringIO()
+    show_graph([obj], empty_edge_function, False, output=output)
+    output_value = output.getvalue()
+    self.assertIsNotNone(output_value)
+    self.assertRegexpMatches(output_value, r'digraph ObjectGraph')
+    self.assertRegexpMatches(output_value,
+                             r'%s\[.*?\]' % obj_node_id(obj))
+
+
+# Doc tests
 
 NODES_VARY = doctest.register_optionflag('NODES_VARY')
 RANDOM_OUTPUT = doctest.register_optionflag('RANDOM_OUTPUT')
@@ -228,7 +263,7 @@ def doctest_edge_label_long_type_names():
     """
 
 
-def test_suite():
+def doc_test_suite():
     doctests = find_doctests()
     return unittest.TestSuite([
         doctest.DocFileSuite(setUp=setUp, tearDown=tearDown,
@@ -238,5 +273,15 @@ def test_suite():
         doctest.DocTestSuite(),
     ])
 
+
+# Test suite rules.
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ShowGraphTest))
+    suite.addTest(doc_test_suite())
+    return suite
+
 if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')
+    unittest.main(defaultTest='suite')

--- a/tests.py
+++ b/tests.py
@@ -15,7 +15,7 @@ from objgraph import show_graph
 try:
   from cStringIO import StringIO
 except ImportError:
-  from StringIO import StringIO
+  from io import StringIO
 
 
 # Unit tests

--- a/tests.py
+++ b/tests.py
@@ -13,9 +13,9 @@ from objgraph import obj_node_id
 from objgraph import show_graph
 
 try:
-  from cStringIO import StringIO
+    from cStringIO import StringIO
 except ImportError:
-  from io import StringIO
+    from io import StringIO
 
 
 class Python25CompatibleTestCaseMixin:
@@ -27,9 +27,6 @@ class Python25CompatibleTestCaseMixin:
             msg = msg or "Regexp didn't match"
             msg = '%s: %r not found in %r' % (msg, expected_regexp.pattern, text)
             raise self.failureException(msg)
-
-    def assertIsNotNone(self, value):
-        self.assertTrue(value is not None)
 
 
 # Unit tests
@@ -44,18 +41,22 @@ class TestObject:
 
 
 class ShowGraphTest(unittest.TestCase, Python25CompatibleTestCaseMixin):
-  """Tests for the show_graph function."""
+    """Tests for the show_graph function."""
 
-  def test_basic_file_output(self):
-    obj = TestObject()
-    output = StringIO()
-    show_graph([obj], empty_edge_function, False, output=output)
-    output_value = output.getvalue()
-    self.assertIsNotNone(output_value)
-    self.assertRegexpMatches(output_value, r'digraph ObjectGraph')
-    self.assertRegexpMatches(output_value,
-                             r'%s\[.*?\]' % obj_node_id(obj))
+    def test_basic_file_output(self):
+        obj = TestObject()
+        output = StringIO()
+        show_graph([obj], empty_edge_function, False, output=output)
+        output_value = output.getvalue()
+        self.assertRegexpMatches(output_value, r'digraph ObjectGraph')
+        self.assertRegexpMatches(output_value,
+                                 r'%s\[.*?\]' % obj_node_id(obj))
 
+    def test_filename_and_output(self):
+        output = StringIO()
+        self.assertRaises(TypeError,
+            show_graph([], empty_edge_function, False, filename='filename',
+                       output=output)
 
 # Doc tests
 
@@ -277,9 +278,10 @@ def doctest_edge_label_long_type_names():
     """
 
 
-def doc_test_suite():
+def suite():
     doctests = find_doctests()
     return unittest.TestSuite([
+        unittest.defaultTestLoader.loadTestsFromName(__name__),
         doctest.DocFileSuite(setUp=setUp, tearDown=tearDown,
                              optionflags=doctest.ELLIPSIS,
                              checker=IgnoreNodeCountChecker(),
@@ -287,15 +289,6 @@ def doc_test_suite():
         doctest.DocTestSuite(),
     ])
 
-
-# Test suite rules.
-
-
-def suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ShowGraphTest))
-    suite.addTest(doc_test_suite())
-    return suite
 
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')


### PR DESCRIPTION
This adds an `output` parameter to `show_graph` which accepts any file-like object (in this case something that supports write()). If `output` is specified, `show_graph` will write to this object instead of creating its own file. 

If `output` is specified then it is illegal to specify `filename`.