### PR TITLE
Preparatory changes for an API version 2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes
 1.8.2 (unreleased)
 ------------------
 
+- Allow user to provide file object rather than specify a filename.
 
 1.8.1 (2014-05-15)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,11 +3,17 @@ Changes
 
 .. currentmodule:: objgraph
 
-1.9.0 (unreleased)
+2.0.0 (unreleased)
 ------------------
+
+- Renamed internal helper functions to be non-public.
+
+- Use logging for all informational output (everything except 
+  :func:`show_most_common_types` and :func:`show_growth`).
 
 - :func:`show_ref` and :func:`show_backref` now accept a file-like object as an
   alternative to a filename.
+
 
 1.8.1 (2014-05-15)
 ------------------

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PYTHON = python
 
+PYLINT = pylint
 FILE_WITH_VERSION = objgraph.py
 FILE_WITH_CHANGELOG = CHANGES.rst
 VCS_STATUS = git status --porcelain
@@ -37,6 +38,10 @@ clean:
 .PHONY: test check
 test check:
 	$(PYTHON) tests.py
+
+.PHONY: lint
+lint:
+	$(PYLINT) objgraph.py
 
 .PHONY: test-all-pythons
 test-all-pythons:

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -24,6 +24,9 @@ You should see a graph like this:
 .. figure:: sample-graph.png
    :alt: [graph of objects reachable from y]
 
+If you prefer to handle your own file output, you can provide a file object to
+the ``output`` parameter of ``show_refs`` and ``show_backrefs`` instead of a
+filename.
 
 Backreferences
 --------------

--- a/objgraph.py
+++ b/objgraph.py
@@ -68,12 +68,12 @@ def count(typename, objects=None):
 
     Example:
 
-      >>> count('dict')
-      42
-      >>> count('MyClass', get_leaking_objects())
-      3
-      >>> count('mymodule.MyClass')
-      2
+        >>> count('dict')
+        42
+        >>> count('MyClass', get_leaking_objects())
+        3
+        >>> count('mymodule.MyClass')
+        2
 
     Note that the GC does not track simple objects like int or str.
 
@@ -103,10 +103,10 @@ def typestats(objects=None, shortnames=True):
 
     Example:
 
-      >>> typestats()
-      {'list': 12041, 'tuple': 10245, ...}
-      >>> typestats(get_leaking_objects())
-      {'MemoryError': 1, 'tuple': 2795, 'RuntimeError': 1, 'list': 47, ...}
+        >>> typestats()
+        {'list': 12041, 'tuple': 10245, ...}
+        >>> typestats(get_leaking_objects())
+        {'MemoryError': 1, 'tuple': 2795, 'RuntimeError': 1, 'list': 47, ...}
 
     .. versionadded:: 1.1
 
@@ -142,8 +142,8 @@ def most_common_types(limit=10, objects=None, shortnames=True):
 
     Example:
 
-      >>> most_common_types(limit=2)
-      [('list', 12041), ('tuple', 10245)]
+        >>> most_common_types(limit=2)
+        [('list', 12041), ('tuple', 10245)]
 
     .. versionadded:: 1.4
 
@@ -168,12 +168,12 @@ def show_most_common_types(limit=10, objects=None, shortnames=True):
 
     Example:
 
-      >>> show_most_common_types(limit=5)
-      tuple            8959
-      function           2442
-      wrapper_descriptor     1048
-      dict             953
-      builtin_function_or_method 800
+        >>> show_most_common_types(limit=5)
+        tuple                      8959
+        function                   2442
+        wrapper_descriptor         1048
+        dict                       953
+        builtin_function_or_method 800
 
     .. versionadded:: 1.1
 
@@ -204,11 +204,11 @@ def show_growth(limit=10, peak_stats=None, shortnames=True):
 
     Example:
 
-      >>> objgraph.show_growth()
-      wrapper_descriptor     970     +14
-      tuple          12282     +10
-      dict          1922    +7
-      ...
+        >>> objgraph.show_growth()
+        wrapper_descriptor       970       +14
+        tuple                  12282       +10
+        dict                    1922       +7
+        ...
 
     .. versionadded:: 1.5
 
@@ -263,8 +263,8 @@ def by_type(typename, objects=None):
 
     Example:
 
-      >>> by_type('MyClass')
-      [<mymodule.MyClass object at 0x...>]
+        >>> by_type('MyClass')
+        [<mymodule.MyClass object at 0x...>]
 
     Note that the GC does not track simple objects like int or str.
 
@@ -289,8 +289,8 @@ def at(addr):
 
     The reverse of id(obj):
 
-      >>> at(id(obj)) is obj
-      True
+        >>> at(id(obj)) is obj
+        True
 
     Note that this function does not work on objects that are not tracked by
     the GC (e.g. ints or strings).
@@ -315,8 +315,8 @@ def find_ref_chain(obj, predicate, max_depth=20, extra_ignore=()):
 
     Example:
 
-      >>> find_chain(obj, lambda x: isinstance(x, MyClass))
-      [obj, ..., <MyClass object at ...>]
+        >>> find_chain(obj, lambda x: isinstance(x, MyClass))
+        [obj, ..., <MyClass object at ...>]
 
     Returns ``[obj]`` if such a chain could not be found.
 
@@ -340,8 +340,8 @@ def find_backref_chain(obj, predicate, max_depth=20, extra_ignore=()):
 
     Example:
 
-      >>> find_backref_chain(obj, is_proper_module)
-      [<module ...>, ..., obj]
+        >>> find_backref_chain(obj, is_proper_module)
+        [<module ...>, ..., obj]
 
     Returns ``[obj]`` if such a chain could not be found.
 
@@ -397,12 +397,12 @@ def show_backrefs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
 
     Examples:
 
-      >>> show_backrefs(obj)
-      >>> show_backrefs([obj1, obj2])
-      >>> show_backrefs(obj, max_depth=5)
-      >>> show_backrefs(obj, filter=lambda x: not inspect.isclass(x))
-      >>> show_backrefs(obj, highlight=inspect.isclass)
-      >>> show_backrefs(obj, extra_ignore=[id(locals())])
+        >>> show_backrefs(obj)
+        >>> show_backrefs([obj1, obj2])
+        >>> show_backrefs(obj, max_depth=5)
+        >>> show_backrefs(obj, filter=lambda x: not inspect.isclass(x))
+        >>> show_backrefs(obj, highlight=inspect.isclass)
+        >>> show_backrefs(obj, extra_ignore=[id(locals())])
 
     .. versionchanged:: 1.3
        New parameters: ``filename``, ``extra_info``.
@@ -462,12 +462,12 @@ def show_refs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
 
     Examples:
 
-      >>> show_refs(obj)
-      >>> show_refs([obj1, obj2])
-      >>> show_refs(obj, max_depth=5)
-      >>> show_refs(obj, filter=lambda x: not inspect.isclass(x))
-      >>> show_refs(obj, highlight=inspect.isclass)
-      >>> show_refs(obj, extra_ignore=[id(locals())])
+        >>> show_refs(obj)
+        >>> show_refs([obj1, obj2])
+        >>> show_refs(obj, max_depth=5)
+        >>> show_refs(obj, filter=lambda x: not inspect.isclass(x))
+        >>> show_refs(obj, highlight=inspect.isclass)
+        >>> show_refs(obj, extra_ignore=[id(locals())])
 
     .. versionadded:: 1.1
 
@@ -498,13 +498,13 @@ def show_chain(*chains, **kw):
     Useful in combination with :func:`find_ref_chain` or
     :func:`find_backref_chain`, e.g.
 
-      >>> show_chain(find_backref_chain(obj, is_proper_module))
+        >>> show_chain(find_backref_chain(obj, is_proper_module))
 
     You can specify if you want that chain traced backwards or forwards
     by passing a ``backrefs`` keyword argument, e.g.
 
-      >>> show_chain(find_ref_chain(obj, is_proper_module),
-      ...      backrefs=False)
+        >>> show_chain(find_ref_chain(obj, is_proper_module),
+        ...            backrefs=False)
 
     Ideally this shouldn't matter, but for some objects
     :func:`gc.get_referrers` and :func:`gc.get_referents` are not perfectly
@@ -551,7 +551,7 @@ def is_proper_module(obj):
     >>> is_proper_module(imp.new_module('foo'))
     False
 
-    .. versionadded:: 1.8.2
+    .. versionadded:: 1.8
     """
     return (inspect.ismodule(obj) and
             obj is sys.modules.get(getattr(obj, '__name__', None)))

--- a/objgraph.py
+++ b/objgraph.py
@@ -350,7 +350,7 @@ def find_backref_chain(obj, predicate, max_depth=20, extra_ignore=()):
 
 def show_backrefs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
                   highlight=None, filename=None, extra_info=None,
-                  refcounts=False, shortnames=True):
+                  refcounts=False, shortnames=True, output=None):
     """Generate an object reference graph ending at ``objs``.
 
     The graph will show you what objects refer to ``objs``, directly and
@@ -363,10 +363,13 @@ def show_backrefs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     file, whose extension indicates the desired output format; note
     that output to a specific format is entirely handled by GraphViz:
     if the desired format is not supported, you just get the .dot
-    file.  If ``filename`` is not specified, ``show_backrefs`` will
-    try to produce a .dot file and spawn a viewer (xdot).  If xdot is
+    file.  If ``filename`` and ``output`` is not specified, ``show_backrefs``
+    will try to produce a .dot file and spawn a viewer (xdot).  If xdot is
     not available, ``show_backrefs`` will convert the .dot file to a
     .png and print its name.
+
+    ``output`` if specified, the GraphViz output will be written to this 
+    file object. ``output`` and ``filename`` should not both be specified.
 
     Use ``max_depth`` and ``too_many`` to limit the depth and breadth of the
     graph.
@@ -405,17 +408,20 @@ def show_backrefs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     .. versionchanged:: 1.8
        New parameter: ``shortnames``.
 
+    .. versionchanged:: 1.8.2
+       New parameter: ``output``.
+
     """
     show_graph(objs, max_depth=max_depth, extra_ignore=extra_ignore,
                filter=filter, too_many=too_many, highlight=highlight,
                edge_func=gc.get_referrers, swap_source_target=False,
-               filename=filename, extra_info=extra_info, refcounts=refcounts,
+               filename=filename, output=output, extra_info=extra_info, refcounts=refcounts,
                shortnames=shortnames)
 
 
 def show_refs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
               highlight=None, filename=None, extra_info=None,
-              refcounts=False, shortnames=True):
+              refcounts=False, shortnames=True, output=None):
     """Generate an object reference graph starting at ``objs``.
 
     The graph will show you what objects are reachable from ``objs``, directly
@@ -428,10 +434,13 @@ def show_refs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     file, whose extension indicates the desired output format; note
     that output to a specific format is entirely handled by GraphViz:
     if the desired format is not supported, you just get the .dot
-    file.  If ``filename`` is not specified, ``show_refs`` will
+    file.  If ``filename`` and ``output`` is not specified, ``show_refs`` will
     try to produce a .dot file and spawn a viewer (xdot).  If xdot is
     not available, ``show_refs`` will convert the .dot file to a
     .png and print its name.
+
+    ``output`` if specified, the GraphViz output will be written to this 
+    file object. ``output`` and ``filename`` should not both be specified.
 
     Use ``max_depth`` and ``too_many`` to limit the depth and breadth of the
     graph.
@@ -467,12 +476,14 @@ def show_refs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     .. versionchanged:: 1.8
        New parameter: ``shortnames``.
 
+    .. versionchanged:: 1.8.2
+       New parameter: ``output``.
     """
     show_graph(objs, max_depth=max_depth, extra_ignore=extra_ignore,
                filter=filter, too_many=too_many, highlight=highlight,
                edge_func=gc.get_referents, swap_source_target=True,
                filename=filename, extra_info=extra_info, refcounts=refcounts,
-               shortnames=shortnames)
+               shortnames=shortnames, output=output)
 
 
 def show_chain(*chains, **kw):
@@ -494,8 +505,8 @@ def show_chain(*chains, **kw):
     symmetrical.
 
     You can specify ``highlight``, ``extra_info``, ``refcounts``,
-    ``shortnames`` or ``filename`` arguments like for :func:`show_backrefs` or
-    :func:`show_refs`.
+    ``shortnames``,``filename`` or ``output`` arguments like for
+    :func:`show_backrefs` or :func:`show_refs`.
 
     .. versionadded:: 1.5
 
@@ -578,10 +589,14 @@ def find_chain(obj, predicate, edge_func, max_depth=20, extra_ignore=()):
 def show_graph(objs, edge_func, swap_source_target,
                max_depth=3, extra_ignore=(), filter=None, too_many=10,
                highlight=None, filename=None, extra_info=None,
-               refcounts=False, shortnames=True):
+               refcounts=False, shortnames=True, output=None):
     if not isinstance(objs, (list, tuple)):
         objs = [objs]
-    if filename and filename.endswith('.dot'):
+    if filename and output:
+        raise ValueError('Cannot specify output and filename.')
+    elif output:
+        f = output
+    elif filename and filename.endswith('.dot'):
         f = codecs.open(filename, 'w', encoding='utf-8')
         dot_filename = filename
     else:
@@ -677,6 +692,10 @@ def show_graph(objs, edge_func, swap_source_target,
             f.write('  too_many_%s[label="%s",shape=box,height=0.25,color=red,fillcolor="%g,%g,%g",fontsize=6];\n' % (obj_node_id(target), label, h, s, v))
             f.write('  too_many_%s[fontcolor=white];\n' % (obj_node_id(target)))
     f.write("}\n")
+    if output:
+        return
+    # The file should only be closed if this function was in charge of opening
+    # the file.
     f.close()
     print("Graph written to %s (%d nodes)" % (dot_filename, nodes))
     if filename and filename.endswith('.dot'):
@@ -685,7 +704,7 @@ def show_graph(objs, edge_func, swap_source_target,
     if not filename and program_in_path('xdot'):
         print("Spawning graph viewer (xdot)")
         subprocess.Popen(['xdot', dot_filename], close_fds=True)
-    elif program_in_path('dot'):
+    elif filename and program_in_path('dot'):
         if not filename:
             print("Graph viewer (xdot) not found, generating a png instead")
             filename = dot_filename[:-4] + '.png'

--- a/objgraph.py
+++ b/objgraph.py
@@ -44,12 +44,16 @@ import subprocess
 import tempfile
 import sys
 import itertools
+import logging
+
+LOG = logging.getLogger('objgraph')
 
 
 try:
     basestring
 except NameError:
     # Python 3.x compatibility
+    # pylint: disable=W0622
     basestring = str
 
 try:
@@ -64,12 +68,12 @@ def count(typename, objects=None):
 
     Example:
 
-        >>> count('dict')
-        42
-        >>> count('MyClass', get_leaking_objects())
-        3
-        >>> count('mymodule.MyClass')
-        2
+      >>> count('dict')
+      42
+      >>> count('MyClass', get_leaking_objects())
+      3
+      >>> count('mymodule.MyClass')
+      2
 
     Note that the GC does not track simple objects like int or str.
 
@@ -84,7 +88,7 @@ def count(typename, objects=None):
     if objects is None:
         objects = gc.get_objects()
     if '.' in typename:
-        return sum(1 for o in objects if long_typename(o) == typename)
+        return sum(1 for o in objects if _long_typename(o) == typename)
     else:
         return sum(1 for o in objects if type(o).__name__ == typename)
 
@@ -99,10 +103,10 @@ def typestats(objects=None, shortnames=True):
 
     Example:
 
-        >>> typestats()
-        {'list': 12041, 'tuple': 10245, ...}
-        >>> typestats(get_leaking_objects())
-        {'MemoryError': 1, 'tuple': 2795, 'RuntimeError': 1, 'list': 47, ...}
+      >>> typestats()
+      {'list': 12041, 'tuple': 10245, ...}
+      >>> typestats(get_leaking_objects())
+      {'MemoryError': 1, 'tuple': 2795, 'RuntimeError': 1, 'list': 47, ...}
 
     .. versionadded:: 1.1
 
@@ -116,13 +120,13 @@ def typestats(objects=None, shortnames=True):
     if objects is None:
         objects = gc.get_objects()
     if shortnames:
-        typename = short_typename
+        typename = _short_typename
     else:
-        typename = long_typename
+        typename = _long_typename
     stats = {}
-    for o in objects:
-        n = typename(o)
-        stats[n] = stats.get(n, 0) + 1
+    for obj in objects:
+        name = typename(obj)
+        stats[name] = stats.get(name, 0) + 1
     return stats
 
 
@@ -138,8 +142,8 @@ def most_common_types(limit=10, objects=None, shortnames=True):
 
     Example:
 
-        >>> most_common_types(limit=2)
-        [('list', 12041), ('tuple', 10245)]
+      >>> most_common_types(limit=2)
+      [('list', 12041), ('tuple', 10245)]
 
     .. versionadded:: 1.4
 
@@ -164,12 +168,12 @@ def show_most_common_types(limit=10, objects=None, shortnames=True):
 
     Example:
 
-        >>> show_most_common_types(limit=5)
-        tuple                      8959
-        function                   2442
-        wrapper_descriptor         1048
-        dict                       953
-        builtin_function_or_method 800
+      >>> show_most_common_types(limit=5)
+      tuple            8959
+      function           2442
+      wrapper_descriptor     1048
+      dict             953
+      builtin_function_or_method 800
 
     .. versionadded:: 1.1
 
@@ -181,12 +185,12 @@ def show_most_common_types(limit=10, objects=None, shortnames=True):
 
     """
     stats = most_common_types(limit, objects, shortnames=shortnames)
-    width = max(len(name) for name, count in stats)
+    width = max(len(name) for name, _ in stats)
     for name, count in stats:
         print('%-*s %i' % (width, name, count))
 
 
-def show_growth(limit=10, peak_stats={}, shortnames=True):
+def show_growth(limit=10, peak_stats=None, shortnames=True):
     """Show the increase in peak object counts since last call.
 
     Limits the output to ``limit`` largest deltas.  You may set ``limit`` to
@@ -200,11 +204,11 @@ def show_growth(limit=10, peak_stats={}, shortnames=True):
 
     Example:
 
-        >>> objgraph.show_growth()
-        wrapper_descriptor       970       +14
-        tuple                  12282       +10
-        dict                    1922        +7
-        ...
+      >>> objgraph.show_growth()
+      wrapper_descriptor     970     +14
+      tuple          12282     +10
+      dict          1922    +7
+      ...
 
     .. versionadded:: 1.5
 
@@ -212,6 +216,8 @@ def show_growth(limit=10, peak_stats={}, shortnames=True):
        New parameter: ``shortnames``.
 
     """
+    if peak_stats is None:
+        peak_stats = {}
     gc.collect()
     stats = typestats(shortnames=shortnames)
     deltas = {}
@@ -258,8 +264,8 @@ def by_type(typename, objects=None):
 
     Example:
 
-        >>> by_type('MyClass')
-        [<mymodule.MyClass object at 0x...>]
+      >>> by_type('MyClass')
+      [<mymodule.MyClass object at 0x...>]
 
     Note that the GC does not track simple objects like int or str.
 
@@ -274,7 +280,7 @@ def by_type(typename, objects=None):
     if objects is None:
         objects = gc.get_objects()
     if '.' in typename:
-        return [o for o in objects if long_typename(o) == typename]
+        return [o for o in objects if _long_typename(o) == typename]
     else:
         return [o for o in objects if type(o).__name__ == typename]
 
@@ -284,8 +290,8 @@ def at(addr):
 
     The reverse of id(obj):
 
-        >>> at(id(obj)) is obj
-        True
+      >>> at(id(obj)) is obj
+      True
 
     Note that this function does not work on objects that are not tracked by
     the GC (e.g. ints or strings).
@@ -310,8 +316,8 @@ def find_ref_chain(obj, predicate, max_depth=20, extra_ignore=()):
 
     Example:
 
-        >>> find_chain(obj, lambda x: isinstance(x, MyClass))
-        [obj, ..., <MyClass object at ...>]
+      >>> find_chain(obj, lambda x: isinstance(x, MyClass))
+      [obj, ..., <MyClass object at ...>]
 
     Returns ``[obj]`` if such a chain could not be found.
 
@@ -335,8 +341,8 @@ def find_backref_chain(obj, predicate, max_depth=20, extra_ignore=()):
 
     Example:
 
-        >>> find_backref_chain(obj, is_proper_module)
-        [<module ...>, ..., obj]
+      >>> find_backref_chain(obj, is_proper_module)
+      [<module ...>, ..., obj]
 
     Returns ``[obj]`` if such a chain could not be found.
 
@@ -368,7 +374,7 @@ def show_backrefs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     not available, ``show_backrefs`` will convert the .dot file to a
     .png and print its name.
 
-    ``output`` if specified, the GraphViz output will be written to this 
+    ``output`` if specified, the GraphViz output will be written to this
     file object. ``output`` and ``filename`` should not both be specified.
 
     Use ``max_depth`` and ``too_many`` to limit the depth and breadth of the
@@ -392,12 +398,12 @@ def show_backrefs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
 
     Examples:
 
-        >>> show_backrefs(obj)
-        >>> show_backrefs([obj1, obj2])
-        >>> show_backrefs(obj, max_depth=5)
-        >>> show_backrefs(obj, filter=lambda x: not inspect.isclass(x))
-        >>> show_backrefs(obj, highlight=inspect.isclass)
-        >>> show_backrefs(obj, extra_ignore=[id(locals())])
+      >>> show_backrefs(obj)
+      >>> show_backrefs([obj1, obj2])
+      >>> show_backrefs(obj, max_depth=5)
+      >>> show_backrefs(obj, filter=lambda x: not inspect.isclass(x))
+      >>> show_backrefs(obj, highlight=inspect.isclass)
+      >>> show_backrefs(obj, extra_ignore=[id(locals())])
 
     .. versionchanged:: 1.3
        New parameters: ``filename``, ``extra_info``.
@@ -415,8 +421,8 @@ def show_backrefs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     show_graph(objs, max_depth=max_depth, extra_ignore=extra_ignore,
                filter=filter, too_many=too_many, highlight=highlight,
                edge_func=gc.get_referrers, swap_source_target=False,
-               filename=filename, output=output, extra_info=extra_info, refcounts=refcounts,
-               shortnames=shortnames)
+               filename=filename, output=output, extra_info=extra_info,
+               refcounts=refcounts, shortnames=shortnames)
 
 
 def show_refs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
@@ -439,7 +445,7 @@ def show_refs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     not available, ``show_refs`` will convert the .dot file to a
     .png and print its name.
 
-    ``output`` if specified, the GraphViz output will be written to this 
+    ``output`` if specified, the GraphViz output will be written to this
     file object. ``output`` and ``filename`` should not both be specified.
 
     Use ``max_depth`` and ``too_many`` to limit the depth and breadth of the
@@ -457,12 +463,12 @@ def show_refs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
 
     Examples:
 
-        >>> show_refs(obj)
-        >>> show_refs([obj1, obj2])
-        >>> show_refs(obj, max_depth=5)
-        >>> show_refs(obj, filter=lambda x: not inspect.isclass(x))
-        >>> show_refs(obj, highlight=inspect.isclass)
-        >>> show_refs(obj, extra_ignore=[id(locals())])
+      >>> show_refs(obj)
+      >>> show_refs([obj1, obj2])
+      >>> show_refs(obj, max_depth=5)
+      >>> show_refs(obj, filter=lambda x: not inspect.isclass(x))
+      >>> show_refs(obj, highlight=inspect.isclass)
+      >>> show_refs(obj, extra_ignore=[id(locals())])
 
     .. versionadded:: 1.1
 
@@ -492,13 +498,13 @@ def show_chain(*chains, **kw):
     Useful in combination with :func:`find_ref_chain` or
     :func:`find_backref_chain`, e.g.
 
-        >>> show_chain(find_backref_chain(obj, is_proper_module))
+      >>> show_chain(find_backref_chain(obj, is_proper_module))
 
     You can specify if you want that chain traced backwards or forwards
     by passing a ``backrefs`` keyword argument, e.g.
 
-        >>> show_chain(find_ref_chain(obj, is_proper_module),
-        ...            backrefs=False)
+      >>> show_chain(find_ref_chain(obj, is_proper_module),
+      ...      backrefs=False)
 
     Ideally this shouldn't matter, but for some objects
     :func:`gc.get_referrers` and :func:`gc.get_referents` are not perfectly
@@ -516,8 +522,9 @@ def show_chain(*chains, **kw):
     """
     backrefs = kw.pop('backrefs', True)
     chains = [chain for chain in chains if chain] # remove empty ones
-    def in_chains(x, ids=set(map(id, itertools.chain(*chains)))):
-        return id(x) in ids
+    ids = set(map(id, itertools.chain(*chains)))
+    def in_chains(obj):
+        return id(obj) in ids
     max_depth = max(map(len, chains)) - 1
     if backrefs:
         show_backrefs([chain[-1] for chain in chains], max_depth=max_depth,
@@ -541,7 +548,7 @@ def is_proper_module(obj):
     >>> is_proper_module(imp.new_module('foo'))
     False
 
-    .. versionadded:: 1.8
+    .. versionadded:: 1.8.2
     """
     return (inspect.ismodule(obj) and
             obj is sys.modules.get(getattr(obj, '__name__', None)))
@@ -552,6 +559,26 @@ def is_proper_module(obj):
 #
 
 def find_chain(obj, predicate, edge_func, max_depth=20, extra_ignore=()):
+    """Finds a single chain from the object until the predicate matches.
+
+    ``obj`` is the starting point of the chain.
+
+    ``predicate`` should be a function that takes an object and returns true
+    if the chain is complete.
+
+    `edge_func` is a function that given a node returns its neighbours.
+
+    `max_depth` is the maximum chain depth before the function should give up.
+    Defaults to 20.
+
+    `extra_ignore` an optional set of object ids that should be ignored
+    when computing neigbours.
+
+    Returns the chain or `[obj]` if no chain was found.
+
+    .. versionadded::1.8
+    """
+
     queue = [obj]
     depth = {id(obj): 0}
     parent = {id(obj): None}
@@ -561,8 +588,9 @@ def find_chain(obj, predicate, edge_func, max_depth=20, extra_ignore=()):
     ignore.add(id(depth))
     ignore.add(id(parent))
     ignore.add(id(ignore))
+    # pylint: disable=W0212
     ignore.add(id(sys._getframe()))  # this function
-    ignore.add(id(sys._getframe(1))) # find_chain/find_backref_chain, most likely
+    ignore.add(id(sys._getframe(1))) # find_chain/find_backref_chain
     gc.collect()
     while queue:
         target = queue.pop(0)
@@ -590,71 +618,122 @@ def show_graph(objs, edge_func, swap_source_target,
                max_depth=3, extra_ignore=(), filter=None, too_many=10,
                highlight=None, filename=None, extra_info=None,
                refcounts=False, shortnames=True, output=None):
+    """Outputs a graph.
+
+    See :func:`show_refs` or :func:`show_backrefs` for more information.
+    """
     if filename and output:
         raise ValueError('Cannot specify output and filename.')
-    if output:
-        f = output
-    elif filename and filename.endswith('.dot'):
-        f = codecs.open(filename, 'w', encoding='utf-8')
+    if filename and filename.endswith('.dot'):
+        output = codecs.open(filename, 'w', encoding='utf-8')
         dot_filename = filename
-    else:
+    elif not output:
         fd, dot_filename = tempfile.mkstemp(prefix='objgraph-',
-                                            suffix='.dot', text=True)
-        f = os.fdopen(fd, "w")
-        if getattr(f, 'encoding', None):
+                                            suffix='.dot',
+                                            text=True)
+        output = os.fdopen(fd, 'w')
+        if getattr(output, 'encoding', None):
             # Python 3 will wrap the file in the user's preferred encoding
             # Re-wrap it for utf-8
             import io
-            f = io.TextIOWrapper(f.detach(), 'utf-8')
+            output = io.TextIOWrapper(output.detach(), 'utf-8')
 
-    nodes = build_graph(objs, edge_func, swap_source_target, f,
-                        max_depth=max_depth, extra_ignore=extra_ignore,
-                        filter=filter, too_many=too_many, highlight=highlight,
-                        extra_info=extra_info, refcounts=refcounts,
-                        shortnames=shortnames)
-    if output:
+    nodes = _build_graph(objs, edge_func, swap_source_target, output,
+                         max_depth=max_depth, extra_ignore=extra_ignore,
+                         filter=filter, too_many=too_many, highlight=highlight,
+                         extra_info=extra_info, refcounts=refcounts,
+                         shortnames=shortnames)
+    if not filename or not dot_filename:
         return
     # The file should only be closed if this function was in charge of opening
     # the file.
-    f.close()
-    print("Graph written to %s (%d nodes)" % (dot_filename, nodes))
+    output.close()
+    LOG.info('Graph written to %s (%d nodes)', dot_filename, nodes)
     if filename and filename.endswith('.dot'):
         # nothing else to do, the user asked for a .dot file
         return
-    if not filename and program_in_path('xdot'):
-        print("Spawning graph viewer (xdot)")
+    if not filename and _program_in_path('xdot'):
+        LOG.info('Spawning graph viewer (xdot)')
         subprocess.Popen(['xdot', dot_filename], close_fds=True)
-    elif filename and program_in_path('dot'):
+    elif dot_filename and _program_in_path('dot'):
         if not filename:
-            print("Graph viewer (xdot) not found, generating a png instead")
+            LOG.warn('Graph viewer (xdot) not found, generating a png instead')
             filename = dot_filename[:-4] + '.png'
-        stem, ext = os.path.splitext(filename)
+        _, ext = os.path.splitext(filename)
         f = open(filename, 'wb')
         dot = subprocess.Popen(['dot', ('-T' + ext[1:]), dot_filename],
                                stdout=f, close_fds=False)
         dot.wait()
         if dot.returncode != 0:
-            # XXX: shouldn't this go to stderr or a log?
-            print("dot failed to generate '%s' image: output format not supported?")
+            LOG.error('dot failed to generate "%s" image:'
+                      ' output format not supported?', filename)
         f.close()
-        print("Image generated as %s" % filename)
+        LOG.info('Image generated as %s', filename)
     else:
         if filename:
-            print("Graph viewer (xdot) and image renderer (dot) not found, not doing anything else")
+            LOG.info('Graph viewer (xdot) and image renderer (dot) not found,'
+                     ' not doing anything else')
         else:
-            print("Unrecognized file type (%s), not doing anything else" % filename)
+            LOG.info('Unrecognized file type (%s), not doing anything else',
+                     filename)
 
+def _output_node(output, obj, depth, max_depth, highlight,
+                 extra_info, refcounts, shortnames):
+    node_id = _obj_node_id(obj)
+    output.write('  %s[label="%s"];\n'
+                 % (node_id,
+                    _obj_label(obj, extra_info, refcounts, shortnames)))
+    hue, sat, val = _gradient((0, 0, 1), (0, 0, .3), depth, max_depth)
+    if depth == 0:
+        output.write('  %s[fontcolor=red];\n' % node_id)
+    if inspect.ismodule(obj):
+        hue = .3
+        sat = 1
+    if highlight and highlight(obj):
+        hue = .6
+        sat = .6
+        val = 0.5 + val * 0.5
+    output.write('  %s[fillcolor="%g,%g,%g"];\n'
+                 % (node_id, hue, sat, val))
+    if val < 0.5:
+        output.write('  %s[fontcolor=white];\n' % node_id)
+    if hasattr(getattr(obj, '__class__', None), '__del__'):
+        output.write('  %s->%s_has_a_del[color=red,style=dotted,len=0.25,'
+                     'weight=10];\n' %
+                     (node_id, node_id))
+        output.write('  %s_has_a_del[label="__del__",shape=doublecircle,'
+                     'height=0.25,color=red,fillcolor="0,.5,1",'
+                     'fontsize=6];\n'
+                     % node_id)
 
+def _output_skipped_node(output, obj, skipped, depth, max_depth,
+                         swap_source_target):
+    node_id = _obj_node_id(obj)
+    hue, sat, val = _gradient((0, 1, 1),
+                              (0, 1, .3),
+                              depth + 1, max_depth)
+    if swap_source_target:
+        label = '%d more references' % skipped
+        edge = '%s->too_many_%s' % (node_id, node_id)
+    else:
+        label = '%d more backreferences' % skipped
+        edge = 'too_many_%s->%s' % (node_id, node_id)
+    output.write('  %s[color=red,style=dotted,len=0.25,weight=10];\n'
+                 % edge)
+    output.write('  too_many_%s[label="%s",shape=box,height=0.25,'
+                 'color=red,fillcolor="%g,%g,%g",fontsize=6];\n'
+                 % (node_id, label, hue, sat, val))
+    output.write('  too_many_%s[fontcolor=white];\n' % node_id)
 
-def build_graph(objs, edge_func, swap_source_target, output,
-               max_depth=3, extra_ignore=(), filter=None, too_many=10,
-               highlight=None, extra_info=None,
-               refcounts=False, shortnames=True):
+def _build_graph(objs, edge_func, swap_source_target, output,
+                 max_depth=3, extra_ignore=(), filter=None, too_many=10,
+                 highlight=None, extra_info=None,
+                 refcounts=False, shortnames=True):
     # Returns the number of nodes created.
     if not isinstance(objs, (list, tuple)):
         objs = [objs]
     output.write('digraph ObjectGraph {\n'
-            '  node[shape=box, style=filled, fillcolor=white];\n')
+                 '  node[shape=box, style=filled, fillcolor=white];\n')
     queue = []
     depth = {}
     ignore = set(extra_ignore)
@@ -663,6 +742,7 @@ def build_graph(objs, edge_func, swap_source_target, output,
     ignore.add(id(queue))
     ignore.add(id(depth))
     ignore.add(id(ignore))
+    # pylint: disable=W0212
     ignore.add(id(sys._getframe()))  # this function
     ignore.add(id(sys._getframe().f_locals))
     ignore.add(id(sys._getframe(1))) # show_graph
@@ -670,7 +750,6 @@ def build_graph(objs, edge_func, swap_source_target, output,
     ignore.add(id(sys._getframe(2))) # show_refs/show_backrefs, most likely
     ignore.add(id(sys._getframe(2).f_locals))
     for obj in objs:
-        output.write('  %s[fontcolor=red];\n' % (obj_node_id(obj)))
         depth[id(obj)] = 0
         queue.append(obj)
         del obj
@@ -680,21 +759,8 @@ def build_graph(objs, edge_func, swap_source_target, output,
         nodes += 1
         target = queue.pop(0)
         tdepth = depth[id(target)]
-        output.write('  %s[label="%s"];\n' % (obj_node_id(target), obj_label(target, extra_info, refcounts, shortnames)))
-        h, s, v = gradient((0, 0, 1), (0, 0, .3), tdepth, max_depth)
-        if inspect.ismodule(target):
-            h = .3
-            s = 1
-        if highlight and highlight(target):
-            h = .6
-            s = .6
-            v = 0.5 + v * 0.5
-        output.write('  %s[fillcolor="%g,%g,%g"];\n' % (obj_node_id(target), h, s, v))
-        if v < 0.5:
-            output.write('  %s[fontcolor=white];\n' % (obj_node_id(target)))
-        if hasattr(getattr(target, '__class__', None), '__del__'):
-            output.write("  %s->%s_has_a_del[color=red,style=dotted,len=0.25,weight=10];\n" % (obj_node_id(target), obj_node_id(target)))
-            output.write('  %s_has_a_del[label="__del__",shape=doublecircle,height=0.25,color=red,fillcolor="0,.5,1",fontsize=6];\n' % (obj_node_id(target)))
+        _output_node(output, target, tdepth, max_depth, highlight,
+                     extra_info, refcounts, shortnames)
         if tdepth >= max_depth:
             continue
         if is_proper_module(target) and not swap_source_target:
@@ -719,8 +785,10 @@ def build_graph(objs, edge_func, swap_source_target, output,
                 srcnode, tgtnode = target, source
             else:
                 srcnode, tgtnode = source, target
-            elabel = edge_label(srcnode, tgtnode, shortnames)
-            output.write('  %s -> %s%s;\n' % (obj_node_id(srcnode), obj_node_id(tgtnode), elabel))
+            elabel = _edge_label(srcnode, tgtnode, shortnames)
+            output.write('  %s -> %s%s;\n' % (_obj_node_id(srcnode),
+                                              _obj_node_id(tgtnode),
+                                              elabel))
             if id(source) not in depth:
                 depth[id(source)] = tdepth + 1
                 queue.append(source)
@@ -728,54 +796,47 @@ def build_graph(objs, edge_func, swap_source_target, output,
             del source
         del neighbours
         if skipped > 0:
-            h, s, v = gradient((0, 1, 1), (0, 1, .3), tdepth + 1, max_depth)
-            if swap_source_target:
-                label = "%d more references" % skipped
-                edge = "%s->too_many_%s" % (obj_node_id(target), obj_node_id(target))
-            else:
-                label = "%d more backreferences" % skipped
-                edge = "too_many_%s->%s" % (obj_node_id(target), obj_node_id(target))
-            output.write('  %s[color=red,style=dotted,len=0.25,weight=10];\n' % edge)
-            output.write('  too_many_%s[label="%s",shape=box,height=0.25,color=red,fillcolor="%g,%g,%g",fontsize=6];\n' % (obj_node_id(target), label, h, s, v))
-            output.write('  too_many_%s[fontcolor=white];\n' % (obj_node_id(target)))
-    output.write("}\n")
+            _output_skipped_node(output, target, skipped, tdepth, max_depth,
+                                 swap_source_target)
+
+    output.write('}\n')
     return nodes
 
 
-def obj_node_id(obj):
+def _obj_node_id(obj):
     return ('o%d' % id(obj)).replace('-', '_')
 
 
-def obj_label(obj, extra_info=None, refcounts=False, shortnames=True):
+def _obj_label(obj, extra_info=None, refcounts=False, shortnames=True):
     if shortnames:
         label = [type(obj).__name__]
     else:
-        label = [long_typename(obj)]
+        label = [_long_typename(obj)]
     if refcounts:
         label[0] += ' [%d]' % (sys.getrefcount(obj) - 4)
         # Why -4?  To ignore the references coming from
-        #   obj_label's frame (obj)
+        #   _obj_label's frame (obj)
         #   show_graph's frame (target variable)
         #   sys.getrefcount()'s argument
         #   something else that doesn't show up in gc.get_referrers()
-    label.append(safe_repr(obj))
+    label.append(_safe_repr(obj))
     if extra_info:
         label.append(str(extra_info(obj)))
-    return quote('\n'.join(label))
+    return _quote('\n'.join(label))
 
 
-def quote(s):
-    return (s.replace("\\", "\\\\")
-             .replace("\"", "\\\"")
-             .replace("\n", "\\n")
-             .replace("\0", "\\\\0"))
+def _quote(s):
+    return (s.replace('\\', '\\\\')
+            .replace('\"', '\\\"')
+            .replace('\n', '\\n')
+            .replace('\0', '\\\\0'))
 
 
-def short_typename(obj):
+def _short_typename(obj):
     return type(obj).__name__
 
 
-def long_typename(obj):
+def _long_typename(obj):
     objtype = type(obj)
     name = objtype.__name__
     module = getattr(objtype, '__module__', None)
@@ -785,14 +846,15 @@ def long_typename(obj):
         return name
 
 
-def safe_repr(obj):
+def _safe_repr(obj):
+    # pylint: disable=W0702
     try:
-        return short_repr(obj)
+        return _short_repr(obj)
     except:
         return '(unrepresentable)'
 
 
-def short_repr(obj):
+def _short_repr(obj):
     if isinstance(obj, (type, types.ModuleType, types.BuiltinMethodType,
                         types.BuiltinFunctionType)):
         return obj.__name__
@@ -816,20 +878,20 @@ def short_repr(obj):
     return repr(obj)[:40]
 
 
-def gradient(start_color, end_color, depth, max_depth):
+def _gradient(start_color, end_color, depth, max_depth):
     if max_depth == 0:
         # avoid division by zero
         return start_color
-    h1, s1, v1 = start_color
-    h2, s2, v2 = end_color
-    f = float(depth) / max_depth
-    h = h1 * (1-f) + h2 * f
-    s = s1 * (1-f) + s2 * f
-    v = v1 * (1-f) + v2 * f
-    return h, s, v
+    hue1, sat1, val1 = start_color
+    hue2, sat2, val2 = end_color
+    fraction = float(depth) / max_depth
+    hue = hue1 * (1-fraction) + hue2 * fraction
+    sat = sat1 * (1-fraction) + sat2 * fraction
+    val = val1 * (1-fraction) + val2 * fraction
+    return hue, sat, val
 
 
-def edge_label(source, target, shortnames=True):
+def _edge_label(source, target, shortnames=True):
     if isinstance(target, dict) and target is getattr(source, '__dict__', None):
         return ' [label="__dict__",weight=10]'
     if isinstance(source, types.FrameType):
@@ -852,27 +914,27 @@ def edge_label(source, target, shortnames=True):
     if isinstance(source, types.FunctionType):
         for k in dir(source):
             if target is getattr(source, k):
-                return ' [label="%s",weight=10]' % quote(k)
+                return ' [label="%s",weight=10]' % _quote(k)
     if isinstance(source, dict):
         for k, v in iteritems(source):
             if v is target:
                 if isinstance(k, basestring) and is_identifier(k):
-                    return ' [label="%s",weight=2]' % quote(k)
+                    return ' [label="%s",weight=2]' % _quote(k)
                 else:
                     if shortnames:
                         tn = type(k).__name__
                     else:
-                        tn = long_typename(k)
-                    return ' [label="%s"]' % quote(tn + "\n" + safe_repr(k))
+                        tn = _long_typename(k)
+                    return ' [label="%s"]' % _quote(tn + '\n' + _safe_repr(k))
     return ''
 
 
 is_identifier = re.compile('[a-zA-Z_][a-zA-Z_0-9]*$').match
 
 
-def program_in_path(program):
-    path = os.environ.get("PATH", os.defpath).split(os.pathsep)
-    path = [os.path.join(dir, program) for dir in path]
-    path = [True for file in path
-            if os.path.isfile(file) or os.path.isfile(file + '.exe')]
+def _program_in_path(program):
+    path = os.environ.get('PATH', os.defpath).split(os.pathsep)
+    path = [os.path.join(_dir, program) for _dir in path]
+    path = [True for _file in path
+            if os.path.isfile(_file) or os.path.isfile(_file + '.exe')]
     return bool(path)

--- a/objgraph.py
+++ b/objgraph.py
@@ -413,7 +413,7 @@ def show_backrefs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     .. versionchanged:: 1.8
        New parameter: ``shortnames``.
 
-    .. versionchanged:: 1.9
+    .. versionchanged:: 2.0
        New parameter: ``output``.
 
     """
@@ -481,7 +481,7 @@ def show_refs(objs, max_depth=3, extra_ignore=(), filter=None, too_many=10,
     .. versionchanged:: 1.8
        New parameter: ``shortnames``.
 
-    .. versionchanged:: 1.9
+    .. versionchanged:: 2.0
        New parameter: ``output``.
 
     """
@@ -519,7 +519,7 @@ def show_chain(*chains, **kw):
     .. versionchanged:: 1.7
        New parameter: ``backrefs``.
 
-    .. versionchanged:: 1.9
+    .. versionchanged:: 2.0
        New parameter: ``output``.
 
     """

--- a/objgraph.py
+++ b/objgraph.py
@@ -29,7 +29,7 @@ Released under the MIT licence.
 __author__ = "Marius Gedminas (marius@gedmin.as)"
 __copyright__ = "Copyright (c) 2008-2015 Marius Gedminas and contributors"
 __license__ = "MIT"
-__version__ = "1.9.0.dev0"
+__version__ = "2.0.0.dev0"
 __date__ = "2014-05-15"
 
 
@@ -226,8 +226,7 @@ def show_growth(limit=10, peak_stats=None, shortnames=True):
         if count > old_count:
             deltas[name] = count - old_count
             peak_stats[name] = count
-    deltas = sorted(deltas.items(), key=operator.itemgetter(1),
-                    reverse=True)
+    deltas = sorted(deltas.items(), key=operator.itemgetter(1), reverse=True)
     if limit:
         deltas = deltas[:limit]
     if deltas:

--- a/pylintrc
+++ b/pylintrc
@@ -40,31 +40,13 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 # evaluation report (RP0004).
 comment=no
 
-# Template used to display messages. This is a python new-style format string
-# used to format the message information. See doc for all details
-#msg-template=
-
-
 [BASIC]
-
-# Required attributes for module, separated by a comma
-required-attributes=
-
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,input
 
 # Good variable names which should always be accepted, separated by a comma
 good-names=i,j,k,ex,Run,_
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata
-
-# Colon-delimited sets of names that determine each other's naming style when
-# the name regexes allow several styles.
-name-group=
-
-# Include a hint for the correct naming format with invalid-name
-include-naming-hint=no
 
 # Regular expression matching correct function names
 function-rgx=[a-z_][a-z0-9_]{2,30}$
@@ -138,7 +120,7 @@ docstring-min-length=10
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=80
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,299 @@
+[MESSAGES CONTROL]
+
+# Disabling:
+# I0011: locally-disabled
+# C0103: invalid-name
+# C0325: superfluous-parens
+# W0621: redefined-outer-name
+# W0622: redefined-builtin
+# W0141: bad-builtin
+# R0911: too-many-return-statments
+# R0912: too-many-branches
+# R0913: too-many-arguments
+# R0914: too-many-locals
+# R0915: too-many-statements
+disable=I0011,C0103,C0325,W0621,W0622,W0141,R0911,R0912,R0913,R0914,R0915
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Add a comment according to your evaluation note. This is used by the global
+# evaluation report (RP0004).
+comment=no
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# Required attributes for module, separated by a comma
+required-attributes=
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=_.*
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=10
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# When zope mode is activated, add a predefined set of Zope acquired attributes
+# to generated-members.
+zope=no
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[CLASSES]
+
+# List of interface methods to ignore, separated by a comma. This is used for
+# instance to not check methods defines in Zope's Interface base class.
+ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
 #!/usr/bin/python
-import codecs, os, re, sys, unittest, doctest
+import codecs
+import doctest
+import logging
+import os
+import re
+import sys
+import unittest
 
 try:
     from setuptools import setup
@@ -65,6 +71,8 @@ def build_images(doctests=()):
     suite = doctest.DocFileSuite(optionflags=doctest.ELLIPSIS,
                                  checker=tests.IgnoreNodeCountChecker(),
                                  *doctests)
+    tests._logger.setLevel(logging.INFO)
+    tests._logger.addHandler(tests._print_handler)
     os.chdir('docs')
     result = unittest.TextTestRunner().run(suite)
     if not result.wasSuccessful():

--- a/tests.py
+++ b/tests.py
@@ -60,7 +60,7 @@ def format(text, **kwargs):
 SINGLE_ELEMENT_OUTPUT = (
     'digraph ObjectGraph {\n'
     '  node[shape=box, style=filled, fillcolor=white];\n'
-    '  ${label_a}[label="${instance}\\nTestObject(A)"];\n'
+    '  ${label_a}[label="TestObject\\nTestObject(A)"];\n'
     '  ${label_a}[fontcolor=red];\n'
     '  ${label_a}[fillcolor="0,0,1"];\n'
     '}\n')
@@ -69,11 +69,11 @@ SINGLE_ELEMENT_OUTPUT = (
 TWO_ELEMENT_OUTPUT = (
     'digraph ObjectGraph {\n'
     '  node[shape=box, style=filled, fillcolor=white];\n'
-    '  ${label_a}[label="${instance}\\nTestObject(A)"];\n'
+    '  ${label_a}[label="TestObject\\nTestObject(A)"];\n'
     '  ${label_a}[fontcolor=red];\n'
     '  ${label_a}[fillcolor="0,0,1"];\n'
     '  ${label_b} -> ${label_a};\n'
-    '  ${label_b}[label="${instance}\\nTestObject(B)"];\n'
+    '  ${label_b}[label="TestObject\\nTestObject(B)"];\n'
     '  ${label_b}[fillcolor="0,0,0.766667"];\n'
     '}\n')
 
@@ -123,7 +123,6 @@ class ShowGraphTest(GarbageCollectedTestCase):
     """Tests for the show_graph function."""
 
     def test_basic_file_output(self):
-        instance = 'TestObject' if sys.version_info[0] > 2 else 'instance'
         obj = TestObject.get("A")
         output = StringIO()
         objgraph.show_graph([obj], empty_edge_function, False, output=output,
@@ -132,11 +131,9 @@ class ShowGraphTest(GarbageCollectedTestCase):
         label = objgraph._obj_node_id(obj)
         self.assertEqual(output_value,
                          format(SINGLE_ELEMENT_OUTPUT,
-                                label_a=label,
-                                instance=instance))
+                                label_a=label))
 
     def test_simple_chain(self):
-        instance = 'TestObject' if sys.version_info[0] > 2 else 'instance'
         edge_fn = edge_function({'A' : 'B'})
         output = StringIO()
         objgraph.show_graph([TestObject.get("A")], edge_fn, False, output=output,
@@ -147,8 +144,7 @@ class ShowGraphTest(GarbageCollectedTestCase):
         self.assertEqual(output_value,
                          format(TWO_ELEMENT_OUTPUT,
                                 label_a=label_a,
-                                label_b=label_b,
-                                instance=instance))
+                                label_b=label_b))
 
     def test_filename_and_output(self):
         output = StringIO()
@@ -204,7 +200,7 @@ class StringRepresentationTest(GarbageCollectedTestCase,
 
         self.assertRegex(
             objgraph._obj_label(x, shortnames=False),
-            r'mymodule\.MyClass\\\\n<mymodule\.MyClass object at .*')
+            'mymodule\.MyClass\\\\n<mymodule\.MyClass object at .*')
 
     def test_long_typename_with_no_module(self):
         x = type('MyClass', (), {'__module__': None})()
@@ -250,7 +246,7 @@ class StringRepresentationTest(GarbageCollectedTestCase,
 
         self.assertRegex(
             objgraph._edge_label(d, 1, shortnames=False),
-            r' [label="mymodule\.MyClass\\n<mymodule\.MyClass object at .*"]')
+            ' [label="mymodule\.MyClass\\n<mymodule\.MyClass object at .*"]')
 
 
 # Doctests

--- a/tests.py
+++ b/tests.py
@@ -11,7 +11,6 @@ import string
 import tempfile
 import unittest
 
-<<<<<<< HEAD
 from objgraph import _obj_node_id
 from objgraph import show_graph
 from objgraph import by_type
@@ -29,7 +28,7 @@ try:
   from cStringIO import StringIO
 except ImportError:
   from io import StringIO
-=======
+
 from objgraph import obj_node_id
 from objgraph import show_graph
 
@@ -49,38 +48,6 @@ class Python25CompatibleTestCaseMixin:
             msg = '%s: %r not found in %r' % (msg, expected_regexp.pattern, text)
             raise self.failureException(msg)
 
-
-# Unit tests
-
-
-def empty_edge_function(obj):
-  return []
-
-
-class TestObject:
-  pass
-
-
-class ShowGraphTest(unittest.TestCase, Python25CompatibleTestCaseMixin):
-    """Tests for the show_graph function."""
-
-    def test_basic_file_output(self):
-        obj = TestObject()
-        output = StringIO()
-        show_graph([obj], empty_edge_function, False, output=output)
-        output_value = output.getvalue()
-        self.assertRegexpMatches(output_value, r'digraph ObjectGraph')
-        self.assertRegexpMatches(output_value,
-                                 r'%s\[.*?\]' % obj_node_id(obj))
-
-    def test_filename_and_output(self):
-        output = StringIO()
-        self.assertRaises(TypeError,
-            show_graph([], empty_edge_function, False, filename='filename',
-                       output=output)
-
-# Doc tests
->>>>>>> origin/file-output
 
 def skipIf(condition, reason):
     def wrapper(fn):
@@ -359,8 +326,6 @@ def find_doctests():
         doctests.discard(os.path.join('docs', 'uncollectable.txt'))
     return sorted(doctests)
 
-
-<<<<<<< HEAD
 def doctest_setup_py_works():
     """Test that setup.py works
 
@@ -375,10 +340,8 @@ def doctest_setup_py_works():
 
     """
 
-def doc_test_suite():
-=======
+
 def suite():
->>>>>>> origin/file-output
     doctests = find_doctests()
     return unittest.TestSuite([
         unittest.defaultTestLoader.loadTestsFromName(__name__),
@@ -390,23 +353,5 @@ def suite():
     ])
 
 
-<<<<<<< HEAD
-# Test suite rules.
-
-
-def suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ShowGraphTest))
-    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(FindChainTest))
-    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TypestatsTest))
-    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ByTypeTest))
-    suite.addTest(
-        unittest.TestLoader().loadTestsFromTestCase(StringRepresentationTest))
-
-    suite.addTest(doc_test_suite())
-    return suite
-
-=======
->>>>>>> origin/file-output
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')

--- a/tests.py
+++ b/tests.py
@@ -9,6 +9,41 @@ import shutil
 import tempfile
 import unittest
 
+from objgraph import obj_node_id
+from objgraph import show_graph
+
+try:
+  from cStringIO import StringIO
+except ImportError:
+  from StringIO import StringIO
+
+
+# Unit tests
+
+
+def empty_edge_function(obj):
+  return []
+
+
+class TestObject:
+  pass
+
+
+class ShowGraphTest(unittest.TestCase):
+  """Tests for the show_graph function."""
+
+  def test_basic_file_output(self):
+    obj = TestObject()
+    output = StringIO()
+    show_graph([obj], empty_edge_function, False, output=output)
+    output_value = output.getvalue()
+    self.assertIsNotNone(output_value)
+    self.assertRegexpMatches(output_value, r'digraph ObjectGraph')
+    self.assertRegexpMatches(output_value, 
+                            r'%s\[.*?\]' % obj_node_id(obj))
+
+
+# Doc tests
 
 NODES_VARY = doctest.register_optionflag('NODES_VARY')
 RANDOM_OUTPUT = doctest.register_optionflag('RANDOM_OUTPUT')
@@ -228,7 +263,21 @@ def doctest_edge_label_long_type_names():
     """
 
 
-def test_suite():
+class DocTestSuite(unittest.TestSuite):
+
+    def __init__(self):
+        doctests = find_doctests()
+        suite = unittest.TestSuite([
+            doctest.DocFileSuite(setUp=setUp, tearDown=tearDown,
+                                 optionflags=doctest.ELLIPSIS,
+                                 checker=IgnoreNodeCountChecker(),
+                                 *doctests),
+            doctest.DocTestSuite(),
+        ])
+        self.addTest(suite)
+        print 'HERE'
+
+def doc_test_suite():
     doctests = find_doctests()
     return unittest.TestSuite([
         doctest.DocFileSuite(setUp=setUp, tearDown=tearDown,
@@ -238,5 +287,15 @@ def test_suite():
         doctest.DocTestSuite(),
     ])
 
+
+# Test suite rules.
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(ShowGraphTest))
+    suite.addTest(doc_test_suite())
+    return suite
+
 if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
This does a few things that should help on a 2.0 API. In particular:

- lint rules -- I'm happy to change what is here, they are mostly the defaults plus some exceptions to rules that I thought were not necessary.
- more test coverage -- I added several tests and also converted the existing doctests to unittests. Some of them probably could have been left as is, but I thought having all the code in doc strings made it harder to follow.
- private functions -- I moved all the functions that were marked as private helpers to begin with an underscore. Moving these out of the API should allow more freedom to change implementation details without bumping the major version.
- logging -- I converted any un-requested printing to use a logger. I say un-requested because show_growth and show_most_common_types still use print statements.