### PR TITLE
support graphing mocked methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,4 +108,5 @@ setup(name='objgraph',
           'Programming Language :: Python :: 3.5',
       ],
       py_modules=['objgraph'],
+      tests_require=['mock'],
       **setuptools_options)

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py26, py27, py33, py34, py35
 
 [testenv]
+deps = mock
 commands =
   python tests.py {posargs}
 


### PR DESCRIPTION
I've found a problem using objgraph to graph the relationships involving methods mocked by the mock library.  Specifically, when applied to a mocked instance method, `_safe_repr` returns a mock, rather than a string, which causes `_obj_label` to fail.  This is because the mock library delegates `__class__` to the spec it is using and it doesn't return `mock.Mock` (or some variant of that).  This PR uses `type()` instead of `__class__` to determine the class of an object.

Assuming you're open to this PR, I'd like to include tests with this PR, but I need to know whether whether you'd be open to include the mock library as a dependency (it is a standard library in python 3 but not before).  If not, I can write lower level tests, but they wouldn't automatically break if mock ever changes how it is implemented (which may or may not be desirable).  Thanks for your consideration and maintaining such a useful tool.