### PR TITLE
Adds get_new_ids and at_addrs functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__/
 .toxbox/
 *.py[co]
 .cache
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 *.py[co]
 .cache
 *.DS_Store
+venv/

--- a/docs/objgraph.txt
+++ b/docs/objgraph.txt
@@ -19,6 +19,7 @@ Statistics
 
 .. autofunction:: show_growth([limit=10, peak_stats={}, shortnames=True, file=sys.stdout])
 
+.. autofunction:: get_new_ids([skip_update=False, limit=10, sortby='deltas'])
 
 Locating and Filtering Objects
 ------------------------------
@@ -28,6 +29,8 @@ Locating and Filtering Objects
 .. autofunction:: by_type(typename[, objects])
 
 .. autofunction:: at
+
+.. autofunction:: at_addrs(address_set)
 
 .. autofunction:: is_proper_module(obj)
 
@@ -44,4 +47,3 @@ Traversing and Displaying Object Graphs
 .. autofunction:: show_backrefs(objs[, max_depth=3, extra_ignore=(), filter=None, too_many=10, highlight=None, filename=None, extra_info=None, refcounts=False, shortnames=True])
 
 .. autofunction:: show_refs(objs[, max_depth=3, extra_ignore=(), filter=None, too_many=10, highlight=None, filename=None, extra_info=None, refcounts=False, shortnames=True])
-

--- a/objgraph.py
+++ b/objgraph.py
@@ -355,6 +355,7 @@ def show_growth(limit=10, peak_stats=None, shortnames=True, file=None,
         for name, count, delta in result:
             file.write('%-*s%9d %+9d\n' % (width, name, count, delta))
 
+
 def get_ids(skip_update=False, limit=10, sortby='deltas',
             OLD_IDS=collections.defaultdict(set),
             CURRENT_IDS=collections.defaultdict(set),
@@ -369,7 +370,8 @@ def get_ids(skip_update=False, limit=10, sortby='deltas',
     called.
 
     CURRENT_IDS: a dictionary which stores sets of ids under the keys of object
-    type. These are the objects that are stored when the function is called now.
+    type. These are the objects that are stored when the function is called
+    now.
 
     NEW_IDS: a dictionary which stores sets of ids under the keys of object
     type. These are the objects that were created between the last time this
@@ -389,12 +391,12 @@ def get_ids(skip_update=False, limit=10, sortby='deltas',
     Example:
 
         >>> get_ids()
-        ==============================================================================
-        Type                            Old_ids  Current_ids      New_ids Count_Deltas
-        ==============================================================================
-        weakref                            3807         3864          +57          +57
-        dict                               6892         6947          +73          +55
-        frame                                34           70          +53          +36
+        ======================================================================
+        Type                    Old_ids  Current_ids      New_ids Count_Deltas
+        ======================================================================
+        weakref                    3807         3864          +57          +57
+        dict                       6892         6947          +73          +55
+        frame                        34           70          +53          +36
         ...
 
     """

--- a/objgraph.py
+++ b/objgraph.py
@@ -434,9 +434,9 @@ def get_new_ids(skip_update=False, limit=10, sortby='deltas',
         current_ids[class_name].clear()
     for o in objects:
         if shortnames:
-            class_name = _short_typename(obj)
+            class_name = _short_typename(o)
         else:
-            class_name = _long_typename(obj)
+            class_name = _long_typename(o)
         id_number = id(o)
         current_ids[class_name].add(id_number)
     for class_name in new_ids:

--- a/objgraph.py
+++ b/objgraph.py
@@ -356,24 +356,13 @@ def show_growth(limit=10, peak_stats=None, shortnames=True, file=None,
             file.write('%-*s%9d %+9d\n' % (width, name, count, delta))
 
 
-def get_new_ids(skip_update=False, limit=10, sortby='deltas',
-            OLD_IDS=collections.defaultdict(set),
-            CURRENT_IDS=collections.defaultdict(set),
-            NEW_IDS=collections.defaultdict(set)):
+def get_new_ids(skip_update=False, limit=10, sortby='deltas', _state ={}):
     """Show the increase in object counts since last call to this function
     and returns the memory address ids for new objects.
 
-    Returns: NEW_IDS
+    Returns: new_ids
 
-    OLD_IDS: a dictionary which stores sets of ids under the keys of object
-    type. These are the objects that were stored the last time the function was
-    called.
-
-    CURRENT_IDS: a dictionary which stores sets of ids under the keys of object
-    type. These are the objects that are stored when the function is called
-    now.
-
-    NEW_IDS: a dictionary which stores sets of ids under the keys of object
+    new_ids: a dictionary which stores sets of ids under the keys of object
     type. These are the objects that were created between the last time this
     function was called and when it was called now.
 
@@ -382,47 +371,79 @@ def get_new_ids(skip_update=False, limit=10, sortby='deltas',
 
     limit: the maximum number of rows that you want to print data for
 
-    if ``skip_update`` is True, the dictionary NEW_IDS
+    _state: a dictionary which stores old, current, and new_ids in memory.
+    Never pass in this argument, it is used by the function to store ids in
+    memory.
+
+    if ``skip_update`` is True, the dictionary new_ids
     will be returned from when the function was last run without examining the
     objects currently in memory.
 
     The caveats documented in :func:`growth` apply.
 
+    When one gets new_ids from get_new_ids, one can use at_addrs to
+    get a list of those objects. Then one can iterate over the new
+    objects, print out what they are, and call show_chain to see where they
+    are referenced.
+
     Example:
 
-        >>> get_new_ids()
+        >>> _ = get_new_ids() # store current objects in _state
+        >>> _ = get_new_ids() # curent_ids become old_ids in _state
+        >>> a = [0, 1, 2] # list we don't know about
+        >>> b = [3, 4, 5] # list we don't know about
+        >>> new_ids = get_new_ids(limit=3) # we see new lists
         ======================================================================
         Type                    Old_ids  Current_ids      New_ids Count_Deltas
         ======================================================================
-        weakref                    3807         3864          +57          +57
-        dict                       6892         6947          +73          +55
-        frame                        34           70          +53          +36
-        ...
-
+        list                        324          326           +3           +2
+        dict                       1125         1125           +0           +0
+        wrapper_descriptor         1001         1001           +0           +0
+        ======================================================================
+        >>> new_lists = at_addrs(new_ids['list'])
+        >>> a in new_lists
+        True
+        >>> b in new_lists
+        True
     """
+    if not _state:
+        _state['old'] = collections.defaultdict(set)
+        _state['current'] = collections.defaultdict(set)
+        _state['new'] = collections.defaultdict(set)
+    new_ids = _state['new']
     if skip_update:
-        return NEW_IDS
+        return new_ids
+    old_ids = _state['old']
+    current_ids = _state['current']
     gc.collect()
     objects = gc.get_objects()
-    for k in OLD_IDS:
-        OLD_IDS[k].clear()
-    for k, v in CURRENT_IDS.items():
-        OLD_IDS[k].update(v)
-    for k in CURRENT_IDS:
-        CURRENT_IDS[k].clear()
+    for class_name in old_ids:
+        old_ids[class_name].clear()
+    for class_name, ids_set in current_ids.items():
+        old_ids[class_name].update(ids_set)
+    for class_name in current_ids:
+        current_ids[class_name].clear()
     for o in objects:
-        CURRENT_IDS[type(o).__name__].add(id(o))
-    for k in NEW_IDS:
-        NEW_IDS[k].clear()
+        class_name = type(o).__name__
+        id_number = id(o)
+        current_ids[class_name].add(id_number)
+    for class_name in new_ids:
+        new_ids[class_name].clear()
     rows = []
-    for class_name in CURRENT_IDS:
-        new_ids_set = CURRENT_IDS[class_name] - OLD_IDS[class_name]
-        NEW_IDS[class_name].update(new_ids_set)
-        row = [class_name,
-               len(OLD_IDS[class_name]),
-               len(CURRENT_IDS[class_name]),
-               len(NEW_IDS[class_name]),
-               len(CURRENT_IDS[class_name]) - len(OLD_IDS[class_name])]
+    for class_name in current_ids:
+        num_old = len(old_ids[class_name])
+        num_current = len(current_ids[class_name])
+        if num_old == 0 and num_current == 0:
+            # remove the key from our dicts if we don't have any old or
+            # curent class_name objects
+            del old_ids[class_name]
+            del current_ids[class_name]
+            del new_ids[class_name]
+            continue
+        new_ids_set = current_ids[class_name] - old_ids[class_name]
+        new_ids[class_name].update(new_ids_set)
+        num_new = len(new_ids_set)
+        row = [class_name, num_old, num_current, num_new, num_current - num_old]
         rows.append(row)
     index_by_sortby = {'old': 1, 'current': 2, 'new': 3, 'deltas': 4}
     rows.sort(key=lambda row: row[index_by_sortby[sortby]], reverse=True)
@@ -433,12 +454,11 @@ def get_new_ids(skip_update=False, limit=10, sortby='deltas',
     print('%-*s%13s%13s%13s%13s' %
           (width, 'Type', 'Old_ids', 'Current_ids', 'New_ids', 'Count_Deltas'))
     print('='*(width+13*4))
-    for row in rows:
-        row_class, old, current, new, delta = row
+    for row_class, old, current, new, delta in rows:
         print('%-*s%13d%13d%+13d%+13d' %
               (width, row_class, old, current, new, delta))
     print('='*(width+13*4))
-    return NEW_IDS
+    return new_ids
 
 
 def get_leaking_objects(objects=None):
@@ -511,21 +531,23 @@ def at(addr):
 
 
 def at_addrs(address_set):
-    """Return objects for a given set of memory addresses.
+    """Returns a list of objects for a given set of memory addresses.
 
-    The reverse of id(obj):
-
-        >>> at(id(obj)) is obj
-        True
+    The reverse of [id(obj1), id(obj2), ...]
 
     Note that this function does not work on objects that are not tracked by
-    the GC (e.g. ints or strings). A good use of this function is to call:
+    the GC (e.g. ints or strings).
 
-        >>> [old, current, new_ids] = get_ids()
-        new_lists = at_addrs(new_ids['list'])
-        for new_list in new_lists:
-            call show_chain on each new_list object
+        >>> a = [0, 1, 2]
+        >>> new_ids = get_new_ids()
+        >>> new_lists = at_addrs(new_ids['list'])
+        >>> a in new_lists
+        True
 
+    When one gets new_ids from get_new_ids, one can use this function to
+    get a list of those objects. Then one can iterate over the new
+    objects, print out what they are, and call show_chain to see where they
+    are referenced.
     """
     res = []
     for o in gc.get_objects():

--- a/objgraph.py
+++ b/objgraph.py
@@ -356,7 +356,7 @@ def show_growth(limit=10, peak_stats=None, shortnames=True, file=None,
             file.write('%-*s%9d %+9d\n' % (width, name, count, delta))
 
 
-def get_new_ids(skip_update=False, limit=10, sortby='deltas', _state ={}):
+def get_new_ids(skip_update=False, limit=10, sortby='deltas', _state={}):
     """Show the increase in object counts since last call to this function
     and returns the memory address ids for new objects.
 
@@ -443,7 +443,8 @@ def get_new_ids(skip_update=False, limit=10, sortby='deltas', _state ={}):
         new_ids_set = current_ids[class_name] - old_ids[class_name]
         new_ids[class_name].update(new_ids_set)
         num_new = len(new_ids_set)
-        row = [class_name, num_old, num_current, num_new, num_current - num_old]
+        num_delta = num_current - num_old
+        row = [class_name, num_old, num_current, num_new, num_delta]
         rows.append(row)
     index_by_sortby = {'old': 1, 'current': 2, 'new': 3, 'deltas': 4}
     rows.sort(key=lambda row: row[index_by_sortby[sortby]], reverse=True)

--- a/objgraph.py
+++ b/objgraph.py
@@ -369,7 +369,8 @@ def get_new_ids(skip_update=False, limit=10, sortby='deltas', _state={}):
     sortby: This is the column that you want to sort by in descending order.
     Possible values are: 'old', 'current', 'new', 'deltas'
 
-    limit: the maximum number of rows that you want to print data for
+    limit: the maximum number of rows that you want to print data for.
+    Value may be None or an integer greater than or equal to 0.
 
     _state: a dictionary which stores old, current, and new_ids in memory.
     Never pass in this argument, it is used by the function to store ids in
@@ -406,8 +407,8 @@ def get_new_ids(skip_update=False, limit=10, sortby='deltas', _state={}):
         >>> b in new_lists
         True
     """
-    if limit < 1:
-        raise ValueError('limit must be greater than or equal to 1')
+    if isinstance(limit, int) and limit < 0:
+        raise ValueError('limit must be greater than or equal to 0')
     if not _state:
         _state['old'] = collections.defaultdict(set)
         _state['current'] = collections.defaultdict(set)
@@ -453,8 +454,10 @@ def get_new_ids(skip_update=False, limit=10, sortby='deltas', _state={}):
         del new_ids[key]
     index_by_sortby = {'old': 1, 'current': 2, 'new': 3, 'deltas': 4}
     rows.sort(key=lambda row: row[index_by_sortby[sortby]], reverse=True)
-    if limit:
+    if isinstance(limit, int):
         rows = rows[:limit]
+    if not rows:
+        return new_ids
     width = max(len(row[0]) for row in rows)
     print('='*(width+13*4))
     print('%-*s%13s%13s%13s%13s' %

--- a/objgraph.py
+++ b/objgraph.py
@@ -27,6 +27,7 @@ Released under the MIT licence.
 
 
 import codecs
+import collections
 import gc
 import re
 import inspect
@@ -431,7 +432,9 @@ def get_ids(skip_update=False, limit=10, sortby='deltas',
           (width, 'Type', 'Old_ids', 'Current_ids', 'New_ids', 'Count_Deltas'))
     print('='*(width+13*4))
     for row in rows:
-        print('%-*s%13d%13d%+13d%+13d' % (width, *row))
+        row_class, old, current, new, delta = row
+        print('%-*s%13d%13d%+13d%+13d' %
+              (width, row_class, old, current, new, delta))
     print('='*(width+13*4))
     return [OLD_IDS, CURRENT_IDS, NEW_IDS]
 


### PR DESCRIPTION
In conducting a memory leak investigation, I found it helpful to look at my new objects created between calls to show_growth. So I made two new functions to help users out here.

get_new_ids is like show_growth, except that it stores dictionaries which hold sets of object address ids.
So now one can grab a set of all the new 'list' ids.

at_addrs: Once one has the new 'list' ids, one can call at_addrs to go from a set of ids to the objects at those addresses. One can then make graphs of the back references on those new objects.
  