### PR TITLE
Allow Github Actions to be run on non-master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: build
 
 on:
   push:
-    branches:
-      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Hi.

I've added a small fix to your Github Actions workflow definition - now it will be executed while pushing commit to any branch instead of just master.
This allows users like me create multiple pull requests from different branches of their fork repos to the master branch of your repo, and still be able to see if something is wrong with the source code.