### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,9 @@ setup(
     author='Marius Gedminas',
     author_email='marius@gedmin.as',
     url='https://mg.pov.lt/objgraph/',
+    project_urls={
+        'Source': 'https://github.com/mgedmin/objgraph',
+    },
     license='MIT',
     description='Draws Python object reference graphs with graphviz',
     long_description=get_description(),


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)