### PR TITLE
Make Python graphviz package dependency optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,10 +84,10 @@ setup(
     ],
     keywords='object graph visualization graphviz garbage collection',
     py_modules=['objgraph'],
-    install_requires=[
-        'graphviz',  # just for ipython support currently
-    ],
     extras_require={
+        'ipython': [
+            'graphviz',  # just for ipython support currently
+        ],
         'test': [
             'mock;python_version=="2.7"',
         ],


### PR DESCRIPTION
Move the Python graphviz package dependency into `ipython` extra
in order to make it optional.  The code already assumes it optional,
and the tests do not need it at all, so this avoids it being
unnecessarily forced for everyone.