### PR TITLE
Drop Python 2 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,10 @@
 [run]
 source = objgraph
-plugins =
-    coverage_python_version
+
+[report]
+exclude_lines =
+    pragma: PY2
+    pragma: nocover
+    except ImportError:
+    except NameError:
+    if __name__ == .__main__.:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "2.7"
           - "3.7"
           - "3.8"
           - "3.9"
@@ -52,7 +51,7 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -U setuptools wheel
-          python -m pip install -U coverage coverage-python-version coveralls
+          python -m pip install -U coverage coveralls
           python -m pip install -e .[test]
 
       - name: Run tests

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,12 +3,12 @@ Changes
 
 .. currentmodule:: objgraph
 
-3.5.1 (unreleased)
+3.6.0 (unreleased)
 ------------------
 
 - Add support for Python 3.9, 3.10, and 3.11.
 
-- Drop support for Python 3.6.
+- Drop support for Python 2.7 and 3.6.
 
 
 3.5.0 (2020-10-11)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endef
 
 .PHONY: coverage
 coverage:                       ##: measure test coverage
-	tox -e coverage2,coverage3
+	tox -e coverage
 
 .PHONY: flake8
 flake8:                         ##: check for style problems

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     # https://www.appveyor.com/docs/installed-software#python lists available
     # versions
-    - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python39"

--- a/objgraph.py
+++ b/objgraph.py
@@ -3,7 +3,7 @@ Tools for drawing Python object reference graphs with graphviz.
 
 You can find documentation online at https://mg.pov.lt/objgraph/
 
-Copyright (c) 2008-2022 Marius Gedminas <marius@pov.lt> and contributors
+Copyright (c) 2008-2023 Marius Gedminas <marius@pov.lt> and contributors
 
 Released under the MIT licence.
 """
@@ -25,8 +25,6 @@ Released under the MIT licence.
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-from __future__ import print_function
-
 import codecs
 import collections
 import gc
@@ -39,38 +37,14 @@ import subprocess
 import sys
 import tempfile
 import types
-
-try:
-    # Python 2.x compatibility
-    from StringIO import StringIO
-except ImportError:  # pragma: PY3
-    from io import StringIO
-
-try:
-    from types import InstanceType
-except ImportError:  # pragma: PY3
-    # Python 3.x compatibility
-    InstanceType = None
-
+from io import StringIO
 
 __author__ = "Marius Gedminas (marius@gedmin.as)"
-__copyright__ = "Copyright (c) 2008-2017 Marius Gedminas and contributors"
+__copyright__ = "Copyright (c) 2008-2023 Marius Gedminas and contributors"
 __license__ = "MIT"
-__version__ = '3.5.1.dev0'
-__date__ = '2020-10-11'
+__version__ = '3.6.0.dev0'
+__date__ = '2023-06-16'
 
-
-try:
-    basestring
-except NameError:  # pragma: PY3
-    # Python 3.x compatibility
-    basestring = str
-
-try:
-    iteritems = dict.iteritems
-except AttributeError:  # pragma: PY3
-    # Python 3.x compatibility
-    iteritems = dict.items
 
 IS_INTERACTIVE = False
 try:  # pragma: nocover
@@ -306,7 +280,7 @@ def growth(limit=10, peak_stats={}, shortnames=True, filter=None):
     gc.collect()
     stats = typestats(shortnames=shortnames, filter=filter)
     deltas = {}
-    for name, count in iteritems(stats):
+    for name, count in stats.items():
         old_count = peak_stats.get(name, 0)
         if count > old_count:
             deltas[name] = count - old_count
@@ -1103,7 +1077,7 @@ def _obj_attrs(obj, extra_node_attrs):
     if extra_node_attrs is not None:
         attrs = extra_node_attrs(obj)
         return ", " + ", ".join('%s="%s"' % (name, _quote(value))
-                                for name, value in sorted(iteritems(attrs))
+                                for name, value in sorted(attrs.items())
                                 if value is not None)
     else:
         return ""
@@ -1136,8 +1110,6 @@ def _quote(s):
 
 def _get_obj_type(obj):
     objtype = type(obj)
-    if type(obj) == InstanceType:  # pragma: PY2 -- no old-style classes on PY3
-        objtype = obj.__class__
     return objtype
 
 
@@ -1168,7 +1140,7 @@ def _name_or_repr(value):
     except AttributeError:
         result = repr(value)[:40]
 
-    if _isinstance(result, basestring):
+    if _isinstance(result, str):
         return result
     else:
         return repr(value)[:40]
@@ -1234,9 +1206,9 @@ def _edge_label(source, target, shortnames=True):
             if target is getattr(source, k):
                 return ' [label="%s",weight=10]' % _quote(k)
     if _isinstance(source, dict):
-        for k, v in iteritems(source):
+        for k, v in source.items():
             if v is target:
-                if _isinstance(k, basestring) and _is_identifier(k):
+                if _isinstance(k, str) and _is_identifier(k):
                     return ' [label="%s",weight=2]' % _quote(k)
                 else:
                     if shortnames:

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -85,15 +84,13 @@ setup(
     ],
     keywords='object graph visualization graphviz garbage collection',
     py_modules=['objgraph'],
+    python_requires=">=3.7",
     extras_require={
         'ipython': [
             'graphviz',  # just for ipython support currently
         ],
-        'test': [
-            'mock;python_version=="2.7"',
-        ],
+        'test': [],
     },
-    tests_require=['mock;python_version=="2.7"'],
     test_suite='tests.test_suite',
     zip_safe=True,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,7 @@
 [tox]
-envlist = py27, py37, py38, py39, py310, py311
+envlist = py37, py38, py39, py310, py311
 
 [testenv]
-deps =
-    py,py27,coverage,coverage2: mock
 commands =
     python tests.py {posargs}
 
@@ -14,22 +12,10 @@ commands =
 
 [testenv:coverage]
 deps =
-    {[testenv]deps}
     coverage
-    coverage-python-version
 commands =
     coverage run tests.py
     coverage report -m --fail-under=100
-
-[testenv:coverage2]
-basepython = python2
-deps = {[testenv:coverage]deps}
-commands = {[testenv:coverage]commands}
-
-[testenv:coverage3]
-basepython = python3
-deps = {[testenv:coverage]deps}
-commands = {[testenv:coverage]commands}
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
The primary reason is that the surrounding Python 2 infrastructure is crumbling (e.g. I can't run tox -e py27 any more because the current virtualenv releases no longer support creating virtualenvs for Python 2).