### PR TITLE
Python 3.13 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - name: Install OS dependencies

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changes
 3.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Python 3.13.
 
 
 3.6.1 (2024-02-26)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
     - PYTHON: "C:\\Python310"
     - PYTHON: "C:\\Python311"
     - PYTHON: "C:\\Python312"
+    - PYTHON: "C:\\Python313"
 
 init:
   - "echo %PYTHON%"

--- a/objgraph.py
+++ b/objgraph.py
@@ -1185,7 +1185,7 @@ def _edge_label(source, target, shortnames=True):
             and target is getattr(source, '__dict__', None)):
         return ' [label="__dict__",weight=10]'
     if _isinstance(source, types.FrameType):
-        if target is source.f_locals:
+        if target is source.f_locals:  # pragma: nocover
             return ' [label="f_locals",weight=10]'
         if target is source.f_globals:
             return ' [label="f_globals",weight=10]'

--- a/release.mk
+++ b/release.mk
@@ -1,4 +1,4 @@
-# release.mk version 2.2.2 (2024-10-09)
+# release.mk version 2.2.3 (2024-10-10)
 #
 # Helpful Makefile rules for releasing Python packages.
 # https://github.com/mgedmin/python-project-skel
@@ -79,7 +79,7 @@ endif
 
 .PHONY: distcheck-sdist
 distcheck-sdist: dist
-	pkg_and_version=`$(PYTHON) setup.py --name|tr .- _`-`$(PYTHON) setup.py --version` && \
+	pkg_and_version=`$(PYTHON) setup.py --name|tr A-Z.- a-z__`-`$(PYTHON) setup.py --version` && \
 	  rm -rf tmp && \
 	  mkdir tmp && \
 	  $(VCS_EXPORT) && \

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     keywords='object graph visualization graphviz garbage collection',
     py_modules=['objgraph'],

--- a/tests.py
+++ b/tests.py
@@ -465,11 +465,6 @@ class StringRepresentationTest(GarbageCollectedMixin,
                          objgraph._gradient((0.1, 0.2, 0.3),
                                             (0.2, 0.3, 0.4), 0, 0))
 
-    def test_edge_label_frame_locals(self):
-        frame = sys._getframe()
-        self.assertEqual(' [label="f_locals",weight=10]',
-                         objgraph._edge_label(frame, frame.f_locals))
-
     def test_edge_label_frame_globals(self):
         frame = sys._getframe()
         self.assertEqual(' [label="f_globals",weight=10]',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, py311, py312
+envlist = py37, py38, py39, py310, py311, py312, py313
 
 [testenv]
 deps =


### PR DESCRIPTION
- Add Python 3.13 support
- `f_locals` labeling doesn't work since Python 3.7, drop the unit test
